### PR TITLE
Change checksum of nginx download

### DIFF
--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -34,7 +34,7 @@ default['nginx']['source']['default_configure_flags'] = %W(
 default['nginx']['configure_flags']    = []
 default['nginx']['source']['version']  = node['nginx']['version']
 default['nginx']['source']['url']      = "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
-default['nginx']['source']['checksum'] = 'b5608c2959d3e7ad09b20fc8f9e5bd4bc87b3bc8ba5936a513c04ed8f1391a18'
+default['nginx']['source']['checksum'] = '8f4b3c630966c044ec72715754334d1fdf741caa1d5795fb4646c27d09f797b7'
 default['nginx']['source']['modules']  = %w(
   nginx::http_ssl_module
   nginx::http_gzip_static_module


### PR DESCRIPTION
I receive this error on our vagrants setup: 

```
==> default: [2016-02-09T02:15:04+00:00] ERROR: remote_file[http://nginx.org/download/nginx-1.8.1.tar.gz] (nginx::source line 58) had an error: Chef::Exceptions::ChecksumMismatch: Checksum on resource (b5608c) does not match checksum on content (8f4b3c)
```

I downloaded the above file manually in the browser and checked its proper checksum:

```shell
➜  Downloads  shasum -a 256 "nginx-1.8.1 (1).tar.gz"
8f4b3c630966c044ec72715754334d1fdf741caa1d5795fb4646c27d09f797b7  nginx-1.8.1 (1).tar.gz
```

So I am updating this checksum in the source.